### PR TITLE
fix: fixing the Outline resize handle overlapping over the toolbar.

### DIFF
--- a/build/styles.css
+++ b/build/styles.css
@@ -10,7 +10,7 @@
   -webkit-transition: 100ms cubic-bezier(0.92, -0.53, 0.65, 1.21);
   min-width: fit-content;
   justify-content: space-around;
-  z-index: var(--layer-status-bar);
+  z-index: var(--layer-popover);
 
 }
 


### PR DESCRIPTION
When the editing toolbar position is set to "following", the Outline left resize handle (i.e., `.workspace-leaf-resize-handle`) has the same z-index as the toolbar which causes it to overlap over the toolbar.

![editing-toolbar](https://github.com/PKM-er/obsidian-editing-toolbar/assets/16526701/58e934df-c7d1-4d61-977e-a77cddbf9962)
