### PR TITLE
fix: making sure the cursor is inside the parenthesis when inserting a link.

### DIFF
--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -533,7 +533,7 @@ export default class cMenuToolbarPlugin extends Plugin {
                                       : (char = 2);
           //@ts-ignore
           app.commands.executeCommandById(`${type["id"]}`);
-          editor.setCursor(curserEnd.line, curserEnd.ch + char);
+          if (type["id"] !== "editor:insert-link") editor.setCursor(curserEnd.line, curserEnd.ch + char);
           await wait(10);
           //@ts-ignore
           app.commands.executeCommandById("editor:focus");


### PR DESCRIPTION
When a user highlights text and selects the `insert link []()` button, the cursor should automatically position itself inside the parentheses. This allows users to conveniently input or paste the link directly without the need to relocate the cursor.