### PR TITLE
fix: hide the Toolbar when the user switches tabs.

### DIFF
--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -653,7 +653,13 @@ export default class cMenuToolbarPlugin extends Plugin {
             toolbar.style.visibility = "visible";
           } catch(err) {
             console.log(toolbar,"toolbar_error");
-          }       
+          }
+        } else {
+          try {
+            toolbar.style.visibility = "hidden";
+          } catch(err) {
+            console.log(toolbar,"toolbar_error");
+          }
         }
 
       } else {


### PR DESCRIPTION
When the user sets the position to "following", We must hide the Toolbar when the user switches tabs.