### PR TITLE
refactor: refactored the positioning system of the toolbar in the "following".

### DIFF
--- a/src/modals/cMenuToolbarModal.ts
+++ b/src/modals/cMenuToolbarModal.ts
@@ -102,16 +102,12 @@ export function selfDestruct() {
 }
 
 export function isExistoolbar(app: App, settings: cMenuToolbarSettings): HTMLElement {
-  const position = settings.positionStyle;
-  let container;
   requireApiVersion("0.15.0") ? activeDocument = activeWindow.document : activeDocument = window.document;
-  position == "top" ? container = app.workspace.activeLeaf?.view.containerEl?.querySelector("#cMenuToolbarModalBar")
-    : container = activeDocument.getElementById("cMenuToolbarModalBar");
-  if (container) {
-    return container as HTMLElement;
-  } else {
-    return null
-  }
+  let container = settings.positionStyle == "top" ?
+      app.workspace.getActiveViewOfType(MarkdownView).containerEl?.querySelector("#cMenuToolbarModalBar") :
+      activeDocument.getElementById("cMenuToolbarModalBar");
+
+   return (container) ? container as HTMLElement : null;
 }
 
 
@@ -479,81 +475,39 @@ export function setFormateraser(app: App, plugin: cMenuToolbarPlugin) {
       app.commands.executeCommandById("editor:focus");
 
     }
-  
+
 }
 export const createFollowingbar = (app: App, settings: cMenuToolbarSettings) => {
-
-  let isource = getModestate(app);
-
+  let isSource = getModestate(app);
   let cMenuToolbarModalBar = isExistoolbar(app, settings);
-  //console.log(activeLeaf.getViewState().state.mode)
-  if (isource) {
-    const activeLeaf = app.workspace.getActiveViewOfType(MarkdownView);
-    const view = activeLeaf;
-    const editor = view.editor;
 
+  if (isSource) {
+    const editor = app.workspace.getActiveViewOfType(MarkdownView).editor;
 
     if (cMenuToolbarModalBar) {
+      cMenuToolbarModalBar.style.visibility = editor.somethingSelected() ? "visible" : "hidden";
+      cMenuToolbarModalBar.addClass("cMenuToolbarFlex");
+      cMenuToolbarModalBar.removeClass("cMenuToolbarGrid");
 
-      let selection = editor.somethingSelected();
-      // let cMenuToolbarRows = settings.cMenuNumRows;
-      selection
-        ? (cMenuToolbarModalBar.style.visibility = "visible")
-        : (cMenuToolbarModalBar.style.visibility = "hidden");
+      const editorRect = activeDocument.querySelectorAll(".markdown-source-view")[0].getBoundingClientRect();
+      const toolbarWidth = cMenuToolbarModalBar.offsetWidth;
+      const toolbarHeight = cMenuToolbarModalBar.offsetHeight;
+      const coords = getCoords(editor);
+      const scrollBarWidth = 12;
 
-      //   let ElementCount = cMenuToolbarModalBar.childElementCount;
-      //   if (ElementCount) {
-      //     ElementCount == cMenuToolbarRows
-      //  ? (cMenuToolbarModalBar.addClass("cMenuToolbarGrid"), cMenuToolbarModalBar.removeClass("cMenuToolbarFlex"))
-      cMenuToolbarModalBar.addClass("cMenuToolbarFlex")
-      cMenuToolbarModalBar.removeClass("cMenuToolbarGrid")
+      let lefPosition = coords.left - editorRect.left;
+      if (lefPosition + toolbarWidth + scrollBarWidth > editorRect.width)
+          lefPosition = editorRect.width - toolbarWidth - scrollBarWidth;
 
-      // let cmheight = Math.ceil(ElementCount / cMenuToolbarRows);
-      let cmheight = 1;
-      cMenuToolbarModalBar.style.height = 40 * cmheight + "px";
-      if (settings.aestheticStyle == "tiny") {
-        cMenuToolbarModalBar.style.height = 25 * cmheight + "px";
-      }
-      let rleftwidth =
-        activeDocument.getElementsByClassName("side-dock-ribbon mod-left")[0]
-          ?.clientWidth ?? 0;
+      let topPosition = coords.top - toolbarHeight;
+      if (topPosition <= editorRect.top) topPosition += toolbarHeight * 2;
 
-      let leftwidth =
-        activeDocument.getElementsByClassName("mod-left-split")[0]
-          ?.clientWidth ?? 0;
-
-      let barwidth = activeDocument.getElementById(
-        "cMenuToolbarModalBar"
-      ).offsetWidth;
-      let barHeight = activeDocument.getElementById(
-        "cMenuToolbarModalBar"
-      ).offsetHeight;
-
-      let bodywidth = activeDocument.body.offsetWidth;
-      let coords = getCoords(editor);
-      let cursor_head = editor.getCursor("head").ch
-      let cursor_from = editor.getCursor("from").ch
-
-      let toppx = 0;
-      /*添加判断边界 */
-      let leftpx = coords.left - leftwidth - rleftwidth + 20;
-      if (coords.left + barwidth + 15 > bodywidth)
-        leftpx = coords.left - leftwidth - rleftwidth - barwidth / 1.3 - 60;
-      if (requireApiVersion("1.0.0"))
-        cursor_head == cursor_from ?
-          toppx = coords.top - barHeight - 10 : (toppx = coords.top + 25, leftpx = leftpx - 40);
-      else cursor_head == cursor_from ?
-        toppx = coords.top - barHeight - 30 : (toppx = coords.top, leftpx = leftpx - 40);
-      if (leftpx < 0) leftpx = 0;
-      cMenuToolbarModalBar.style.visibility == "visible" ?
-        (cMenuToolbarModalBar.style.left = leftpx + "px", cMenuToolbarModalBar.style.top = toppx + "px") : true;
-
+      cMenuToolbarModalBar.style.left = lefPosition + "px";
+      cMenuToolbarModalBar.style.top = topPosition + "px";
     }
-
-
-  } else
-    cMenuToolbarModalBar.style.visibility = "hidden"
+  } else cMenuToolbarModalBar.style.visibility = "hidden"
 }
+
 export function cMenuToolbarPopover(
   app: App,
   plugin: cMenuToolbarPlugin

--- a/src/modals/cMenuToolbarModal.ts
+++ b/src/modals/cMenuToolbarModal.ts
@@ -156,21 +156,11 @@ export const getCoords = (editor: any) => {
   return coords;
 };
 
-export function getModestate(app: App) {
+export function isSource(app: App) {
   const activePane = app.workspace.getActiveViewOfType(MarkdownView);
- // const view = app.workspace.getActiveViewOfType(ItemView);
-  //console.log(view?.getState().mode,"getState")
- 
-  if (activePane) {
-    let currentmode = activePane?.getMode();
-    if (currentmode == "preview") {
-      return false;
-    } else
-      if (currentmode == "source") {
-        return true;
-      } else
-        return false;
-  }
+
+  if (activePane) return activePane.getMode() === "source";
+  return false;
 }
 
 export function checkHtml(htmlStr: string) {
@@ -478,19 +468,19 @@ export function setFormateraser(app: App, plugin: cMenuToolbarPlugin) {
 
 }
 export const createFollowingbar = (app: App, settings: cMenuToolbarSettings) => {
-  let isSource = getModestate(app);
   let cMenuToolbarModalBar = isExistoolbar(app, settings);
 
-  if (isSource) {
+  if (isSource(app)) {
     const editor = app.workspace.getActiveViewOfType(MarkdownView).editor;
 
     if (cMenuToolbarModalBar) {
       cMenuToolbarModalBar.style.visibility = editor.somethingSelected() ? "visible" : "hidden";
+      cMenuToolbarModalBar.style.height = (settings.aestheticStyle === "tiny") ? 30 + "px" : 40 + "px";
       cMenuToolbarModalBar.addClass("cMenuToolbarFlex");
       cMenuToolbarModalBar.removeClass("cMenuToolbarGrid");
 
       if (cMenuToolbarModalBar.style.visibility === "visible") {
-          const editorRect = activeDocument.querySelectorAll(".markdown-source-view")[0].getBoundingClientRect();
+          const editorRect = editor.containerEl.getBoundingClientRect();
           const toolbarWidth = cMenuToolbarModalBar.offsetWidth;
           const toolbarHeight = cMenuToolbarModalBar.offsetHeight;
           const coords = getCoords(editor);

--- a/src/modals/cMenuToolbarModal.ts
+++ b/src/modals/cMenuToolbarModal.ts
@@ -489,21 +489,23 @@ export const createFollowingbar = (app: App, settings: cMenuToolbarSettings) => 
       cMenuToolbarModalBar.addClass("cMenuToolbarFlex");
       cMenuToolbarModalBar.removeClass("cMenuToolbarGrid");
 
-      const editorRect = activeDocument.querySelectorAll(".markdown-source-view")[0].getBoundingClientRect();
-      const toolbarWidth = cMenuToolbarModalBar.offsetWidth;
-      const toolbarHeight = cMenuToolbarModalBar.offsetHeight;
-      const coords = getCoords(editor);
-      const scrollBarWidth = 12;
+      if (cMenuToolbarModalBar.style.visibility === "visible") {
+          const editorRect = activeDocument.querySelectorAll(".markdown-source-view")[0].getBoundingClientRect();
+          const toolbarWidth = cMenuToolbarModalBar.offsetWidth;
+          const toolbarHeight = cMenuToolbarModalBar.offsetHeight;
+          const coords = getCoords(editor);
+          const scrollBarWidth = 12;
 
-      let lefPosition = coords.left - editorRect.left;
-      if (lefPosition + toolbarWidth + scrollBarWidth > editorRect.width)
-          lefPosition = editorRect.width - toolbarWidth - scrollBarWidth;
+          let lefPosition = coords.left - editorRect.left;
+          if (lefPosition + toolbarWidth + scrollBarWidth > editorRect.width)
+              lefPosition = editorRect.width - toolbarWidth - scrollBarWidth;
 
-      let topPosition = coords.top - toolbarHeight;
-      if (topPosition <= editorRect.top) topPosition += toolbarHeight * 2;
+          let topPosition = coords.top - toolbarHeight;
+          if (topPosition <= editorRect.top) topPosition += toolbarHeight * 2;
 
-      cMenuToolbarModalBar.style.left = lefPosition + "px";
-      cMenuToolbarModalBar.style.top = topPosition + "px";
+          cMenuToolbarModalBar.style.left = lefPosition + "px";
+          cMenuToolbarModalBar.style.top = topPosition + "px";
+      }
     }
   } else cMenuToolbarModalBar.style.visibility = "hidden"
 }

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -18,7 +18,7 @@ import { wait } from "src/util/util";
 import { appIcons } from "src/icons/appIcons";
 import { CommandPicker, openSlider } from "src/modals/suggesterModals";
 import { cMenuToolbarSettingTab } from "src/settings/settingsTab";
-import { selfDestruct, cMenuToolbarPopover, getModestate, quiteFormatbrushes, setFontcolor, setBackgroundcolor, setHeader, createFollowingbar, setFormateraser, isExistoolbar, resetToolbar } from "src/modals/cMenuToolbarModal";
+import { selfDestruct, cMenuToolbarPopover, isSource, quiteFormatbrushes, setFontcolor, setBackgroundcolor, setHeader, createFollowingbar, setFormateraser, isExistoolbar, resetToolbar } from "src/modals/cMenuToolbarModal";
 import { cMenuToolbarSettings, DEFAULT_SETTINGS } from "src/settings/settingsData";
 import addIcons, {
   // addFeatherIcons,
@@ -803,13 +803,13 @@ export default class cMenuToolbarPlugin extends Plugin {
       // console.log(cMenuToolbarModalBar,"cMenuToolbarModalBar" )
       //let view = this.app.workspace.getActiveViewOfType(MarkdownView) || true
       let view = true
-      if ((getModestate(app) === false) || (!view)) //no source mode
+      if (!isSource(app) || (!view)) //no source mode
       {
         if (cMenuToolbarModalBar) {
           cMenuToolbarModalBar.style.visibility = "hidden"
         }
       }
-      else if (getModestate(app) === true) {
+      else if (isSource(app)) {
         if (cMenuToolbarModalBar) {
           if (this.settings.positionStyle == "following")
             cMenuToolbarModalBar.style.visibility = "hidden"
@@ -838,7 +838,7 @@ export default class cMenuToolbarPlugin extends Plugin {
     // console.log(type,"handlecMenuToolbar_layout" )
     //requireApiVersion("0.15.0") ? activeDocument = activeWindow.document : activeDocument = window.document;
     if (this.settings.cMenuVisibility == true && this.settings.positionStyle == "top") {
-      if (getModestate(app)) {
+      if (isSource(app)) {
           let leafwidth = this.app.workspace.activeLeaf.view.leaf.width ?? 0
           //let leafwidth = view.containerEl?.querySelector<HTMLElement>(".markdown-source-view").offsetWidth ?? 0
           if (this.Leaf_Width == leafwidth) return false;


### PR DESCRIPTION
- Refactor the way the toolbar's position is calculated for the "following" mode to make sure the toolbar:
  - Is always visible, even when we the user selects the last or first line in the editor. (which was not the case before this commit)
  - To try not to overflow over the File Explorer or the Outline.
 
- Refactord isExistoolbar() to get rid of deprecated code (i.e., [`activeLeaf`](https://docs.obsidian.md/Reference/TypeScript+API/Workspace/activeLeaf)), and to simplify the code.

- Refactored `getModestate()` into `isSource()`: since `getModestate()` doesn't really get the mode state, but rather returns whether the MarkdownView mode state is "source" or not, I renamed it to `isSource()` to reflect just that, and simplified the function implementation in the process.
