### PR TITLE
Replace <span> tags with <mark> for highlights

### DIFF
--- a/build/styles.css
+++ b/build/styles.css
@@ -785,11 +785,11 @@ button[class^=editingToolbarCommandsubItem]::after {
   opacity: 0;
 }
 
-:is(.cm-line, p) span[style^="background:rgba"] {
+:is(.cm-line, p) mark[style^="background:rgba"] {
   color: var(--text-normal);
 }
 
-:is(.cm-line, p) span[style^="background:#"] {
+:is(.cm-line, p) mark[style^="background:#"] {
   color: black;
 }
 

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -633,7 +633,7 @@ processAdmonitionTypes(pluginInstance: any) {
           this.lastExecutedCommand = "editing-toolbar:change-font-color";
           this.lastExecutedCommandName = "Font Color";
           detectedFormat = true;
-        } else if (/^<span style="background:.*">.*<\/span>$/.test(selectedText)) {
+        } else if (/^<mark style="background:.*">.*<\/mark>$/.test(selectedText)) {
           // 背景颜色
           this.lastExecutedCommand = "editing-toolbar:change-background-color";
           this.lastExecutedCommandName = "Background Color";
@@ -904,7 +904,7 @@ processAdmonitionTypes(pluginInstance: any) {
 
         // 检测背景颜色
 
-        const bgColorRegex = /<span style="background:([^"]+)">([^<]+)<\/span>/g;
+        const bgColorRegex = /<mark style="background:([^"]+)">([^<]+)<\/mark>/g;
         while ((match = bgColorRegex.exec(lineText)) !== null) {
           const formatStart = match.index;
           const formatEnd = match.index + match[0].length;

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -329,14 +329,14 @@ export function setBackgroundcolor(color: string, editor?: Editor) {
   }
 
   // Regex to match background color tags, with multiline support
-  const bgColorRegex = /<span\s+style=["']?background:(?:#[0-9a-fA-F]{3,6}|rgba?\([^)]+\))["']?>([\s\S]*?)<\/span>/g;
+  const bgColorRegex = /<mark\s+style=["']?background:(?:#[0-9a-fA-F]{3,6}|rgba?\([^)]+\))["']?>([\s\S]*?)<\/mark>/g;
   const hasColorTag = bgColorRegex.test(selectText);
 
   // Function to check if the text is already wrapped in the same background color
   const isAlreadyInSameColor = (text: string, targetColor: string): boolean => {
     // 转义正则表达式中的特殊字符，特别是对于rgba格式
     const escapedColor = targetColor.replace(/([()[{*+.$^\\|?])/g, '\\$1');
-    const cleanColorRegex = new RegExp(`^<span\\s+style=["']?background:${escapedColor}["']?>([\s\S]+)<\\/span>$`);
+    const cleanColorRegex = new RegExp(`^<mark\\s+style=["']?background:${escapedColor}["']?>([\s\S]+)<\\/mark>$`);
     return cleanColorRegex.test(text.trim());
   };
 
@@ -353,14 +353,14 @@ export function setBackgroundcolor(color: string, editor?: Editor) {
   } else {
     // 如果没有背景色标签，为每行添加背景色
     finalText = selectText.split('\n').map(line => 
-      line.trim() ? `<span style="background:${color}">${line}</span>` : line
+      line.trim() ? `<mark style="background:${color}">${line}</mark>` : line
     ).join('\n');
   }
 
   // Store the current selection
   const currentSelection = editor.listSelections();
   const adjustedSelections = currentSelection.map(sel => {
-    const tagLength = hasColorTag ? 0 : `<span style="background:${color}"></span>`.length;
+    const tagLength = hasColorTag ? 0 : `<mark style="background:${color}"></mark>`.length;
     const isForward = sel.anchor.line < sel.head.line || 
                       (sel.anchor.line === sel.head.line && sel.anchor.ch < sel.head.ch);
 


### PR DESCRIPTION
Replacing `<span>` tags with `<mark>` tags improves consistency with modern HTML syntax. Also, the [Highlightr plugin](https://github.com/chetachiezikeuzor/Highlightr-Plugin) utilizes the `<mark>` syntax, allowing for a more seamless integration in terms of display.

This PR closes #256.
