### PR TITLE
Fix staggered toolbar disappearance in some themes

### DIFF
--- a/src/modals/editingToolbarModal.ts
+++ b/src/modals/editingToolbarModal.ts
@@ -332,6 +332,7 @@ export function createMoremenu(app: App, plugin: editingToolbarPlugin, selector:
         Morecontainer.style.visibility = "visible";
         Morecontainer.style.height = "32px";
       } else {
+        Morecontainer.style.display = "none";
         Morecontainer.style.visibility = "hidden";
         Morecontainer.style.height = "0";
       }
@@ -450,6 +451,7 @@ export function createFollowingbar(
   const view = app.workspace.getActiveViewOfType(ItemView);
   if (!ViewUtils.isAllowedViewType(view)) {
     if (editingToolbarModalBar) {
+      editingToolbarModalBar.style.display = "none";
       editingToolbarModalBar.style.visibility = "hidden";
     }
     return;
@@ -483,10 +485,16 @@ export function createFollowingbar(
       if (editingToolbarModalBar) {
         // 当 forceShow 为 true 或有文本选中时显示工具栏
         const shouldShow = forceShow || editor.somethingSelected();
-        editingToolbarModalBar.style.visibility = shouldShow ? "visible" : "hidden";
+        if (shouldShow) {
+          editingToolbarModalBar.style.display = "";
+          editingToolbarModalBar.style.visibility = "visible";
+        } else {
+          editingToolbarModalBar.style.display = "none";
+          editingToolbarModalBar.style.visibility = "hidden";
+        }
 
         // 仅在工具栏可见时执行后续操作
-        if (editingToolbarModalBar.style.visibility === "visible") {
+        if (shouldShow) {
           // 设置工具栏样式
           editingToolbarModalBar.style.height = height + "px";
           editingToolbarModalBar.addClass("editingToolbarFlex");
@@ -499,12 +507,14 @@ export function createFollowingbar(
     } else {
       // 阅读模式隐藏工具栏
       if (editingToolbarModalBar) {
+        editingToolbarModalBar.style.display = "none";
         editingToolbarModalBar.style.visibility = "hidden";
       }
     }
   } else {
     // 处理其他视图类型（canvas等）
     if (editingToolbarModalBar) {
+      editingToolbarModalBar.style.display = "";
       editingToolbarModalBar.style.visibility = "visible";
       editingToolbarModalBar.style.height = height + "px";
       editingToolbarModalBar.addClass("editingToolbarFlex");
@@ -690,17 +700,17 @@ export function editingToolbarPopover(
       let btnwidth = 0;
       let leafwidth = 0;
       let buttonWidth = resolvedIconSize + 8;
-    
+
       // 主工具栏容器
       let editingToolbar = createEl("div");
       if (editingToolbar) {
         // 标记为编辑工具栏，并带上样式信息
         editingToolbar.addClass("editingToolbarModalBar");
         editingToolbar.setAttribute("data-toolbar-style", effectiveStyle);
-    
+
         // Note: cMenuVisibility is already checked at function start, so we don't need to check here
         // Toolbars should only be created when cMenuVisibility is true
-        
+
         if (effectiveStyle === "top") {
           editingToolbar.className += " top";
           if (settings.autohide) {
@@ -712,6 +722,7 @@ export function editingToolbarPopover(
           // If cMenuVisibility is false, visibility is already set to hidden above
         } else if (effectiveStyle === "following") {
           // following 工具栏初始隐藏，待选中文本后定位并显示
+          editingToolbar.style.display = "none";
           editingToolbar.style.visibility = "hidden";
         } else if (effectiveStyle === "fixed") {
           const Rowsize = resolvedIconSize || 18;
@@ -725,22 +736,23 @@ export function editingToolbarPopover(
       }
       // 继续保留旧的 id，以兼容当前 CSS
       editingToolbar.setAttribute("id", "editingToolbarModalBar");
-    
+
       // 二级弹出菜单
       let PopoverMenu = createEl("div");
       PopoverMenu.addClass("editingToolbarpopover");
       PopoverMenu.addClass("editingToolbarTinyAesthetic");
-    
+
       // 标记为 Popover 工具栏，并带上样式信息
       PopoverMenu.addClass("editingToolbarPopoverBar");
       PopoverMenu.setAttribute("data-toolbar-style", effectiveStyle);
-    
+
       // 继续保留旧的 id，以兼容当前 CSS
       PopoverMenu.setAttribute("id", "editingToolbarPopoverBar");
-    
+
+      PopoverMenu.style.display = "none";
       PopoverMenu.style.visibility = "hidden";
       PopoverMenu.style.height = "0";
-    
+
       // Apply per-style aesthetic
       applyAestheticStyle(editingToolbar, resolvedAestheticStyle);
       applyAestheticStyle(PopoverMenu, resolvedAestheticStyle);
@@ -809,19 +821,19 @@ export function editingToolbarPopover(
 
         // 只有在没有工具栏时才添加 PopoverMenu
         if (!currentleaf?.querySelector("#editingToolbarPopoverBar")) {
-         if (viewType == "excalidraw") {
-          targetDom.insertAdjacentElement("afterend", PopoverMenu);
-         } else {
-          targetDom.insertAdjacentElement("afterbegin", PopoverMenu);
-         }
+          if (viewType == "excalidraw") {
+            targetDom.insertAdjacentElement("afterend", PopoverMenu);
+          } else {
+            targetDom.insertAdjacentElement("afterbegin", PopoverMenu);
+          }
         }
 
         // 添加编辑工具栏
-       if (viewType == "excalidraw") {
-        targetDom.insertAdjacentElement("afterend", editingToolbar);
-       } else {
-        targetDom.insertAdjacentElement("afterbegin", editingToolbar);
-       }
+        if (viewType == "excalidraw") {
+          targetDom.insertAdjacentElement("afterend", editingToolbar);
+        } else {
+          targetDom.insertAdjacentElement("afterbegin", editingToolbar);
+        }
 
         // 获取宽度
         leafwidth = targetDom?.offsetWidth;
@@ -913,12 +925,15 @@ export function editingToolbarPopover(
                         const hasSelection = editor && editor.somethingSelected();
 
                         if (settings.cMenuVisibility == false) {
+                          editingToolbar.style.display = "none";
                           editingToolbar.style.visibility = "hidden";
                         } else if (effectiveStyle === "following") {
                           if (!hasSelection) {
+                            editingToolbar.style.display = "none";
                             editingToolbar.style.visibility = "hidden";
                           }
                         } else {
+                          editingToolbar.style.display = "";
                           editingToolbar.style.visibility = "visible";
                         }
                       });
@@ -958,13 +973,16 @@ export function editingToolbarPopover(
                       const hasSelection = editor && editor.somethingSelected();
 
                       if (settings.cMenuVisibility == false) {
+                        editingToolbar.style.display = "none";
                         editingToolbar.style.visibility = "hidden";
                       } else if (effectiveStyle === "following") {
                         // For the following toolbar, only show when there is a selection.
                         if (!hasSelection) {
+                          editingToolbar.style.display = "none";
                           editingToolbar.style.visibility = "hidden";
                         }
                       } else {
+                        editingToolbar.style.display = "";
                         editingToolbar.style.visibility = "visible";
                       }
 
@@ -975,7 +993,7 @@ export function editingToolbarPopover(
                   }
                   if (subitem.id == "editingToolbar-Divider-Line") {
                     sub_btn.setClass("editingToolbar-Divider-Line");
-                    
+
                     sub_btn.buttonEl.setAttribute('aria-label', subitem.name);
                   }
                   checkHtml(subitem.icon)
@@ -1000,15 +1018,18 @@ export function editingToolbarPopover(
                 // 检查命令执行后是否仍有文本选中
                 const editor = plugin.commandsManager.getActiveEditor();
                 const hasSelection = editor && editor.somethingSelected();
-  
+
                 if (settings.cMenuVisibility == false) {
+                  editingToolbar.style.display = "none";
                   editingToolbar.style.visibility = "hidden";
                 } else if (effectiveStyle === "following") {
                   // For the following toolbar, only show when there is a selection.
                   if (!hasSelection) {
+                    editingToolbar.style.display = "none";
                     editingToolbar.style.visibility = "hidden";
                   }
                 } else {
+                  editingToolbar.style.display = "";
                   editingToolbar.style.visibility = "visible";
                 }
 
@@ -1084,15 +1105,18 @@ export function editingToolbarPopover(
                 // 检查命令执行后是否仍有文本选中
                 const editor = plugin.commandsManager.getActiveEditor();
                 const hasSelection = editor && editor.somethingSelected();
-  
+
                 if (settings.cMenuVisibility == false) {
+                  editingToolbar.style.display = "none";
                   editingToolbar.style.visibility = "hidden";
                 } else if (effectiveStyle === "following") {
                   // For the following toolbar, only show when there is a selection.
                   if (!hasSelection) {
+                    editingToolbar.style.display = "none";
                     editingToolbar.style.visibility = "hidden";
                   }
                 } else {
+                  editingToolbar.style.display = "";
                   editingToolbar.style.visibility = "visible";
                 }
 
@@ -1174,13 +1198,16 @@ export function editingToolbarPopover(
               const hasSelection = editor && editor.somethingSelected();
 
               if (settings.cMenuVisibility == false) {
+                editingToolbar.style.display = "none";
                 editingToolbar.style.visibility = "hidden";
               } else if (effectiveStyle === "following") {
                 // For the following toolbar, only show when there is a selection.
                 if (!hasSelection) {
+                  editingToolbar.style.display = "none";
                   editingToolbar.style.visibility = "hidden";
                 }
               } else {
+                editingToolbar.style.display = "";
                 editingToolbar.style.visibility = "visible";
               }
 
@@ -1264,11 +1291,11 @@ export function editingToolbarPopover(
       }
 
       // 工具栏不存在，创建新的
-  
-      generateMenu();
-     
 
-  
+      generateMenu();
+
+
+
 
       // 缓存新创建的工具栏（但 top 工具栏不缓存，因为每个 leaf 都有独立的工具栏）
       // Note: cMenuVisibility is already checked at function start, so toolbars are only created when visible

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -34,7 +34,7 @@ import { InsertCalloutModal } from "src/modals/insertCalloutModal";
 let activeDocument: Document;
 
 // ---- Per-style appearance support (patch v3, integrated) ----
-import type { AppearanceByStyle, ToolbarStyleKey, StyleAppearanceSettings} from "src/settings/settingsData";
+import type { AppearanceByStyle, ToolbarStyleKey, StyleAppearanceSettings } from "src/settings/settingsData";
 
 const STYLE_KEYS: ToolbarStyleKey[] = ["top", "following", "fixed", "mobile"];
 
@@ -78,7 +78,7 @@ function ensureAppearanceStore(
   }
 }
 // ---- end per-style appearance helpers ----
-export interface AdmonitionDefinition  {
+export interface AdmonitionDefinition {
   type: string;
   title?: string;
   icon: string;
@@ -103,10 +103,10 @@ export default class editingToolbarPlugin extends Plugin {
   statusBar: StatusBar;
   public toolbarIconSize: number; // 新增全局变量
   public positionStyle: string;
-  
+
   // NEW: which style's appearance is being edited in the settings UI
   public appearanceEditStyle: ToolbarStyleKey | null = null;
-  
+
   // 修改为公共属性
   commandsManager: CommandsManager;
   public admonitionDefinitions: Record<string, AdmonitionDefinition> | null =
@@ -137,7 +137,7 @@ export default class editingToolbarPlugin extends Plugin {
 
 
 
-    // Initialise per-style appearance (patch v3 logic, but limited to this plugin)
+  // Initialise per-style appearance (patch v3 logic, but limited to this plugin)
   private initPerStyleAppearance(): void {
     const settings = this.settings;
     if (!settings) return;
@@ -146,7 +146,7 @@ export default class editingToolbarPlugin extends Plugin {
     ensureAppearanceStore(settings, migratingFromGlobal);
 
     const store = settings.appearanceByStyle as AppearanceByStyle;
-    
+
     const getCurrentStyle = (): ToolbarStyleKey => {
       const raw = (
         this.appearanceEditStyle ||       // 1. style we are editing in settings
@@ -191,14 +191,14 @@ export default class editingToolbarPlugin extends Plugin {
   async onload(): Promise<void> {
     const currentVersion = this.manifest.version; // 设置当前版本号
     console.log("editingToolbar v" + currentVersion + " loaded");
-  
+
     requireApiVersion("0.15.0") ? activeDocument = activeWindow.document : activeDocument = window.document;
-  
+
     await this.loadSettings();
-  
+
     // IMPORTANT: wire up per-style getters/setters before we start using appearance fields
     this.initPerStyleAppearance();
-  
+
     this.settingTab = new editingToolbarSettingTab(this.app, this);
     this.addSettingTab(this.settingTab);
 
@@ -210,7 +210,7 @@ export default class editingToolbarPlugin extends Plugin {
     this.app.workspace.onLayoutReady(() => {
       this.statusBar = new StatusBar(this);
       this.statusBar.init();
-      
+
       // Ensure toolbar respects initial visibility state after Settings Search completes
       // Use a small delay to ensure Settings Search has finished scanning settings tabs
       setTimeout(() => {
@@ -261,7 +261,7 @@ export default class editingToolbarPlugin extends Plugin {
     const isThinoEnabled = app.plugins.enabledPlugins.has("obsidian-memos");
     if (isThinoEnabled) {
       // @ts-ignore - 自定义事件
-      this.registerEvent( this.app.workspace.on("thino-editor-created", this.handleeditingToolbar)
+      this.registerEvent(this.app.workspace.on("thino-editor-created", this.handleeditingToolbar)
       );
     }
     this.registerEvent(
@@ -297,10 +297,10 @@ export default class editingToolbarPlugin extends Plugin {
       },
     );
 
-// 最好等待工作区布局准备好，确保所有插件都已加载
-this.app.workspace.onLayoutReady(async () => {
-  await this.tryGetAdmonitionTypes();
-});
+    // 最好等待工作区布局准备好，确保所有插件都已加载
+    this.app.workspace.onLayoutReady(async () => {
+      await this.tryGetAdmonitionTypes();
+    });
 
     // // 注册右键菜单
     // this.registerEvent(
@@ -400,10 +400,10 @@ this.app.workspace.onLayoutReady(async () => {
     // @ts-ignore
     const admonitionPluginInstance = this.app.plugins?.getPlugin(ADMONITION_PLUGIN_ID);
     if (admonitionPluginInstance) {
-       
-        this.processAdmonitionTypes(admonitionPluginInstance);
-      }  
+
+      this.processAdmonitionTypes(admonitionPluginInstance);
     }
+  }
 
   processAdmonitionTypes(pluginInstance: any) {
     const admonitionPlugin = pluginInstance as {
@@ -421,12 +421,12 @@ this.app.workspace.onLayoutReady(async () => {
     ) {
       registeredTypes = Object.keys(admonitionPlugin.admonitions);
       this.admonitionDefinitions = admonitionPlugin.admonitions;
-   
-  }  else {
-    console.warn('未能从 admonitionPlugin.admonitions (作为对象) 获取类型。');
-    this.admonitionDefinitions = null; 
+
+    } else {
+      console.warn('未能从 admonitionPlugin.admonitions (作为对象) 获取类型。');
+      this.admonitionDefinitions = null;
+    }
   }
-}
 
   isLoadMobile() {
     let screenWidth = window.innerWidth > 0 ? window.innerWidth : screen.width;
@@ -490,7 +490,10 @@ this.app.workspace.onLayoutReady(async () => {
     if (!ViewUtils.isAllowedViewType(view)) {
       (["top", "following", "fixed"] as const).forEach((style) => {
         const el = isExistoolbar(this.app, this, style);
-        if (el) el.style.visibility = "hidden";
+        if (el) {
+          el.style.display = "none";
+          el.style.visibility = "hidden";
+        }
       });
       return;
     }
@@ -504,7 +507,10 @@ this.app.workspace.onLayoutReady(async () => {
     if (isMarkdownView && !inSourceMode) {
       (["top", "following", "fixed"] as const).forEach((style) => {
         const el = isExistoolbar(this.app, this, style);
-        if (el) el.style.visibility = "hidden";
+        if (el) {
+          el.style.display = "none";
+          el.style.visibility = "hidden";
+        }
       });
       return;
     }
@@ -517,17 +523,17 @@ this.app.workspace.onLayoutReady(async () => {
       typeof (this as any).isTopToolbarActive === "function"
         ? (this as any).isTopToolbarActive()
         : this.settings.enableTopToolbar ||
-          (!this.settings.enableFollowingToolbar &&
-            !this.settings.enableFixedToolbar &&
-            this.positionStyle === "top");
+        (!this.settings.enableFollowingToolbar &&
+          !this.settings.enableFixedToolbar &&
+          this.positionStyle === "top");
 
     const followingEnabled =
       typeof (this as any).isFollowingToolbarActive === "function"
         ? this.isFollowingToolbarActive()
         : this.settings.enableFollowingToolbar ||
-          (!this.settings.enableTopToolbar &&
-            !this.settings.enableFixedToolbar &&
-            this.positionStyle === "following");
+        (!this.settings.enableTopToolbar &&
+          !this.settings.enableFixedToolbar &&
+          this.positionStyle === "following");
 
     const fixedEnabled =
       this.settings.enableFixedToolbar ||
@@ -536,9 +542,9 @@ this.app.workspace.onLayoutReady(async () => {
         this.positionStyle === "fixed");
 
     const styles: { key: "top" | "following" | "fixed"; enabled: boolean }[] = [
-      { key: "top",       enabled: topEnabled },
+      { key: "top", enabled: topEnabled },
       { key: "following", enabled: followingEnabled },
-      { key: "fixed",     enabled: fixedEnabled },
+      { key: "fixed", enabled: fixedEnabled },
     ];
 
     // ---- Per-style handling: create / show / hide independently ----
@@ -547,7 +553,10 @@ this.app.workspace.onLayoutReady(async () => {
 
       if (!enabled) {
         // Style disabled in settings → hide any existing toolbar of that style.
-        if (existing) existing.style.visibility = "hidden";
+        if (existing) {
+          existing.style.display = "none";
+          existing.style.visibility = "hidden";
+        }
         continue;
       }
 
@@ -564,14 +573,17 @@ this.app.workspace.onLayoutReady(async () => {
         // Following toolbar only works in markdown source mode
         // For other views (Canvas, etc.), hide it
         if (!inSourceMode) {
+          toolbar.style.display = "none";
           toolbar.style.visibility = "hidden";
         } else {
           // In markdown source mode, stays hidden until text is selected.
           // Your `showFollowingToolbar` / selection handlers will reveal it.
+          toolbar.style.display = "none";
           toolbar.style.visibility = "hidden";
         }
       } else {
         // Top / Fixed: visible in markdown source mode and other allowed views
+        toolbar.style.display = "";
         toolbar.style.visibility = "visible";
       }
     }
@@ -582,34 +594,34 @@ this.app.workspace.onLayoutReady(async () => {
     // just recompute toolbar creation/visibility using the main handler.
     this.handleeditingToolbar();
   };
-  
+
   handleeditingToolbar_resize = () => {
     // Only care about resizing when the toolbar is visible and top-style is active
     if (!this.settings.cMenuVisibility || !this.isTopToolbarActive()) {
       return false;
     }
-  
+
     const view = app.workspace.getActiveViewOfType(ItemView);
     if (!ViewUtils.isSourceMode(view)) {
       return false;
     }
-  
+
     const leafwidth = this.app.workspace.activeLeaf.view.leaf.width ?? 0;
     // No width, or nothing changed → nothing to do
     if (leafwidth <= 0 || this.Leaf_Width === leafwidth) {
       return false;
     }
-  
+
     this.Leaf_Width = leafwidth;
-  
+
     if (this.settings.cMenuWidth && leafwidth) {
       const diff = leafwidth - this.settings.cMenuWidth;
-  
+
       // Same guard as before: don't rebuild if the configured width still fits
       if (diff < 78 && leafwidth > this.settings.cMenuWidth) {
         return;
       }
-  
+
       setTimeout(() => {
         resetToolbar(this);
         editingToolbarPopover(app, this);
@@ -689,41 +701,41 @@ this.app.workspace.onLayoutReady(async () => {
   }
 
   // 更新指定样式对应的命令配置（设置页可以显式指定样式）
-updateCurrentCommands(commands: any[], style?: string): void {
-  // 单一配置模式：一直使用 menuCommands
-  if (!this.settings.enableMultipleConfig) {
-    this.settings.menuCommands = commands;
-    return;
-  }
+  updateCurrentCommands(commands: any[], style?: string): void {
+    // 单一配置模式：一直使用 menuCommands
+    if (!this.settings.enableMultipleConfig) {
+      this.settings.menuCommands = commands;
+      return;
+    }
 
-  // 如果没有显式传入 style，则保持旧逻辑：根据当前环境决定目标样式
-  let targetStyle = style;
+    // 如果没有显式传入 style，则保持旧逻辑：根据当前环境决定目标样式
+    let targetStyle = style;
 
-  if (!targetStyle) {
-    if (this.settings.isLoadOnMobile && Platform.isMobileApp) {
-      targetStyle = 'mobile';
-    } else {
-      targetStyle = this.positionStyle;
+    if (!targetStyle) {
+      if (this.settings.isLoadOnMobile && Platform.isMobileApp) {
+        targetStyle = 'mobile';
+      } else {
+        targetStyle = this.positionStyle;
+      }
+    }
+
+    switch (targetStyle) {
+      case 'following':
+        this.settings.followingCommands = commands;
+        break;
+      case 'top':
+        this.settings.topCommands = commands;
+        break;
+      case 'fixed':
+        this.settings.fixedCommands = commands;
+        break;
+      case 'mobile':
+        this.settings.mobileCommands = commands;
+        break;
+      default:
+        this.settings.menuCommands = commands;
     }
   }
-
-  switch (targetStyle) {
-    case 'following':
-      this.settings.followingCommands = commands;
-      break;
-    case 'top':
-      this.settings.topCommands = commands;
-      break;
-    case 'fixed':
-      this.settings.fixedCommands = commands;
-      break;
-    case 'mobile':
-      this.settings.mobileCommands = commands;
-      break;
-    default:
-      this.settings.menuCommands = commands;
-  }
-}
 
   async saveSettings() {
     await this.saveData(this.settings);
@@ -1168,8 +1180,8 @@ updateCurrentCommands(commands: any[], style?: string): void {
       if (this.formatBrushNotice) this.formatBrushNotice.hide();
       this.formatBrushNotice = new Notice(
         t("Format brush ON! Select text to apply【") +
-          this.lastExecutedCommandName +
-          t("】format"),
+        this.lastExecutedCommandName +
+        t("】format"),
         0
       );
     } else {
@@ -1303,7 +1315,7 @@ updateCurrentCommands(commands: any[], style?: string): void {
     const cached = this.toolbarCache.get(style);
     // 验证缓存的元素是否仍在 DOM 中
     if (cached && cached.isConnected) {
-    
+
       return cached;
     }
     // 缓存失效，清除
@@ -1354,7 +1366,7 @@ updateCurrentCommands(commands: any[], style?: string): void {
     if (this.settings.enableTopToolbar) {
       return true;
     }
-  
+
     // Backwards compatibility fallback:
     // if neither following nor fixed have been explicitly enabled,
     // and the old global positionStyle is "top", behave like old single-mode.
@@ -1365,7 +1377,7 @@ updateCurrentCommands(commands: any[], style?: string): void {
     ) {
       return true;
     }
-  
+
     return false;
   }
 
@@ -1461,6 +1473,7 @@ updateCurrentCommands(commands: any[], style?: string): void {
   private hideToolbarIfNotSelected() {
     const followingToolbar = isExistoolbar(this.app, this, "following");
     if (followingToolbar && this.isFollowingToolbarActive()) {
+      followingToolbar.style.display = "none";
       followingToolbar.style.visibility = "hidden";
     }
   }
@@ -1518,6 +1531,7 @@ updateCurrentCommands(commands: any[], style?: string): void {
     const followingToolbar = isExistoolbar(this.app, this, "following");
 
     if (followingToolbar) {
+      followingToolbar.style.display = "";
       followingToolbar.style.visibility = "visible";
       followingToolbar.classList.add("editingToolbarFlex");
       followingToolbar.classList.remove("editingToolbarGrid");
@@ -1534,11 +1548,11 @@ updateCurrentCommands(commands: any[], style?: string): void {
     // Temporarily ignore any "editing style" override while we update the live toolbar
     const previousEditStyle = this.appearanceEditStyle;
     this.appearanceEditStyle = null;
-  
+
     // Track the new style both in-memory and in settings
     this.positionStyle = newStyle;
     this.settings.positionStyle = newStyle;
-  
+
     // If multi-config is enabled, ensure the command arrays for this style exist
     if (this.settings.enableMultipleConfig) {
       switch (newStyle) {
@@ -1572,10 +1586,10 @@ updateCurrentCommands(commands: any[], style?: string): void {
           break;
       }
     }
-  
+
     // Keep the in-memory size in sync with the active style
     this.toolbarIconSize = this.settings.toolbarIconSize;
-  
+
     // Refresh the global CSS variables from the *active* style's appearance
     const doc = activeDocument ?? document;
     if (doc && doc.documentElement) {
@@ -1592,9 +1606,9 @@ updateCurrentCommands(commands: any[], style?: string): void {
         `${this.settings.toolbarIconSize}px`
       );
     }
-  
+
     dispatchEvent(new Event("editingToolbar-NewCommand"));
-  
+
     // Restore whatever the settings UI was editing
     this.appearanceEditStyle = previousEditStyle;
   }

--- a/styles.css
+++ b/styles.css
@@ -15,8 +15,8 @@
   user-select: none;
   border-radius: var(--radius-m);
   position: absolute;
-  transition: 100ms cubic-bezier(0.92, -0.53, 0.65, 1.21);
-  -webkit-transition: 100ms cubic-bezier(0.92, -0.53, 0.65, 1.21);
+  transition: transform 100ms cubic-bezier(0.92, -0.53, 0.65, 1.21), opacity 100ms cubic-bezier(0.92, -0.53, 0.65, 1.21), top 100ms cubic-bezier(0.92, -0.53, 0.65, 1.21), left 100ms cubic-bezier(0.92, -0.53, 0.65, 1.21);
+  -webkit-transition: -webkit-transform 100ms cubic-bezier(0.92, -0.53, 0.65, 1.21), opacity 100ms cubic-bezier(0.92, -0.53, 0.65, 1.21), top 100ms cubic-bezier(0.92, -0.53, 0.65, 1.21), left 100ms cubic-bezier(0.92, -0.53, 0.65, 1.21);
   min-width: fit-content;
   justify-content: space-around;
   z-index: var(--layer-modal);
@@ -411,8 +411,8 @@ button[class^=editingToolbarCommandsubItem]::after {
   background-color: var(--background-secondary);
   z-index:1;
   visibility: hidden;
-  transition: all 0.15s linear;
-  -webkit-transition: all 0.15s linear;
+  transition: transform 0.15s linear, opacity 0.15s linear;
+  -webkit-transition: -webkit-transform 0.15s linear, opacity 0.15s linear;
 }
 
 
@@ -421,8 +421,8 @@ button[class^=editingToolbarCommandsubItem]::after {
 
 :is(#editingToolbarModalBar, #editingToolbarPopoverBar) button[class^=editingToolbarCommandsubItem] >.subitem:hover  {
   visibility:visible;
-  transition: all 0.3s linear;
-  -webkit-transition:  all 0.3s linear;
+  transition: transform 0.3s linear, opacity 0.3s linear;
+  -webkit-transition: -webkit-transform 0.3s linear, opacity 0.3s linear;
 }
 
 :is(#editingToolbarModalBar, #editingToolbarPopoverBar) button[class^=editingToolbarCommandsubItem]:first-child>.subitem
@@ -513,20 +513,20 @@ button[class^=editingToolbarCommandsubItem]::after {
 
 :is(#editingToolbarModalBar, #editingToolbarPopoverBar) button.editingToolbarCommandsubItem-font-color .subitem {
   visibility: hidden;
-  transition: all 0.15s linear;
-  -webkit-transition: all 0.15s linear;
+  transition: transform 0.15s linear, opacity 0.15s linear;
+  -webkit-transition: -webkit-transform 0.15s linear, opacity 0.15s linear;
 }
 
 :is(#editingToolbarModalBar, #editingToolbarPopoverBar) button.editingToolbarCommandsubItem-font-color .subitem:hover {
   visibility: visible;
-  transition: all 0.3s linear;
-  -webkit-transition: all 0.3s linear;
+  transition: transform 0.3s linear, opacity 0.3s linear;
+  -webkit-transition: -webkit-transform 0.3s linear, opacity 0.3s linear;
 }
 
 :is(#editingToolbarModalBar, #editingToolbarPopoverBar) button[class^=editingToolbarCommandsubItem]:hover>.subitem {
   visibility: visible;
-  transition: all 0.3s linear;
-  -webkit-transition: all 0.3s linear;
+  transition: transform 0.3s linear, opacity 0.3s linear;
+  -webkit-transition: -webkit-transform 0.3s linear, opacity 0.3s linear;
   z-index:1;
 }
 
@@ -755,8 +755,8 @@ button[class^=editingToolbarCommandsubItem]::after {
   position: relative;
   height: calc(var(--toolbar-icon-size) + 18px);
   align-items: center;
-  transition: all 0.2s linear;
-  -webkit-transition: all 0.2s linear;
+  transition: transform 0.2s linear, opacity 0.2s linear, top 0.2s linear, left 0.2s linear;
+  -webkit-transition: -webkit-transform 0.2s linear, opacity 0.2s linear, top 0.2s linear, left 0.2s linear;
   transform: none;
   z-index: var(--layer-status-bar);
 }
@@ -774,8 +774,8 @@ button[class^=editingToolbarCommandsubItem]::after {
 }
 #editingToolbarModalBar.top.autohide {
   opacity: 0;
-  transition: all 0.5s linear;
-  -webkit-transition: all 0.5s linear;
+  transition: opacity 0.5s linear;
+  -webkit-transition: opacity 0.5s linear;
 }
 #editingToolbarModalBar.top.centered {
   max-width: var(--file-line-width) ;
@@ -784,8 +784,8 @@ button[class^=editingToolbarCommandsubItem]::after {
 
 #editingToolbarModalBar.top.autohide:hover {
   opacity: 1;
-  transition: all 1s linear;
-  -webkit-transition: all 1s linear;
+  transition: opacity 1s linear;
+  -webkit-transition: opacity 1s linear;
 }
 
 
@@ -832,8 +832,8 @@ button[class^=editingToolbarCommandsubItem]::after {
   border-radius: var(--radius-m);
   margin-left: 25px;
   margin-right: 25px;
-  transition: all 0.1s linear;
-  -webkit-transition: all 0.1s linear;
+  transition: transform 0.1s linear, opacity 0.1s linear, top 0.1s linear, left 0.1s linear, background-color 0.1s linear;
+  -webkit-transition: -webkit-transform 0.1s linear, opacity 0.1s linear, top 0.1s linear, left 0.1s linear, background-color 0.1s linear;
   position: absolute;
   right: 0;
 }
@@ -866,8 +866,8 @@ button[class^=editingToolbarCommandsubItem]::after {
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  transition: all 0.2s linear;
-  -webkit-transition: all 0.2s linear;
+  transition: transform 0.2s linear, opacity 0.2s linear;
+  -webkit-transition: -webkit-transform 0.2s linear, opacity 0.2s linear;
 
 }
 
@@ -1503,4 +1503,16 @@ body.auto-hide-header .workspace-tab-header-container + .workspace-tab-container
 .is-phone .mod-root .workspace-leaf-content .view-content:has(.editingToolbarModalBar) .markdown-reading-view > .markdown-preview-view
  {
   padding-top: calc(var(--safe-area-inset-top) + var(--view-header-height) + 36px);
+}
+/* Robust fix for staggered disappearance by bypassing transitions */
+[class*="editingToolbarModalBar"][style*="visibility: hidden"],
+#editingToolbarPopoverBar[style*="visibility: hidden"] {
+    display: none !important;
+}
+
+/* Also ensure no transitions linger on icons */
+[class*="editingToolbarModalBar"] *,
+#editingToolbarPopoverBar * {
+    transition: none !important;
+    animation: none !important;
 }


### PR DESCRIPTION
In some themes (like [cupertino](https://github.com/aaaaalexis/obsidian-cupertino)), the editing toolbar disappears in two steps: the background vanishes semi-instantly, and the buttons/icons linger for a fraction of a second. This is caused by broad CSS transitions (e.g., `transition: all 0.3s`) in the theme that also apply to the `visibility` property. When a plugin sets `visibility: hidden`, the browser delays the state change until the transition completes, causing the staggered effect:

https://github.com/user-attachments/assets/e1525eed-374c-4ea3-8c9a-b550a975ea95

Proposing the following solution:

- Instant Hiding via `display: none`: Updated `main.ts `and `editingToolbarModal.ts` to toggle `display: none` alongside `visibility: hidden`. This bypasses all CSS transitions and ensures the toolbar vanishes instantly.
- Refined CSS Transitions: Replaced generic `transition: all` in `styles.css` with specific property transitions (`transform`, `opacity`, `top`, `left`) to prevent accidental `visibility` transitions.
- CSS Fail-safe: Added a CSS rule to force `display: none !important` whenever the plugin applies `visibility: hidden` via inline styles, serving as a robust backstop against theme overrides.

Built and tested locally, the solution works, but it's very blunt, I'm assuming there is a more elegant way to fix that, please take a look.