### PR TITLE
Fix staggered toolbar disappearance in some themes [2]

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1057,11 +1057,15 @@ body:has(.workspace-leaf.mod-active .cm-ai-loading, .workspace-leaf.mod-active .
   
 }
 
-:is(#editingToolbarModalBar, #editingToolbarPopoverBar) :is(.editingToolbarCommandItem, button[class^=editingToolbarCommandsubItem]):not(.editingToolbar-Divider-Line) *:not(.subitem)
-{
-animation: none ;
-transition: none ;
- 
+/* Some themes animate all workspace SVG icons. Opt toolbar controls out so
+   inherited visibility changes hide the whole toolbar in one frame. */
+:is(#editingToolbarModalBar, #editingToolbarPopoverBar) :is(.editingToolbarCommandItem, button[class^=editingToolbarCommandsubItem]):not(.editingToolbar-Divider-Line),
+:is(#editingToolbarModalBar, #editingToolbarPopoverBar) :is(.editingToolbarCommandItem, button[class^=editingToolbarCommandsubItem]):not(.editingToolbar-Divider-Line) *:not(.subitem),
+:is(#editingToolbarModalBar, #editingToolbarPopoverBar) svg.svg-icon,
+:is(#editingToolbarModalBar, #editingToolbarPopoverBar) svg.svg-icon * {
+animation: none;
+transition: none !important;
+-webkit-transition: none !important;
 }
 #editingToolbarModalBar ~.canvas-controls{
   top: calc(var(--size-4-2) + 50px);


### PR DESCRIPTION
Continuation of https://github.com/PKM-er/obsidian-editing-toolbar/pull/294, behavior is exactly the same, still present in latest version [4.0.3](https://github.com/PKM-er/obsidian-editing-toolbar/releases/tag/4.0.3).

I've investigated it a little more this time and done more concise fix purely touching `styles.css.`

The toolbar container was being hidden immediately, but the button icons could linger briefly because the theme applies broad transitions to `svg.svg-icon` inside the workspace.

The fix is CSS-only. It keeps the existing toolbar show/hide logic unchanged and instead opts the toolbar controls and their SVG icons out of inherited transitions. That makes `visibility: hidden` take effect visually in one frame, so the toolbar background and icons disappear together.

What changed:

- Added a narrow transition reset for toolbar buttons and toolbar SVG icons in `styles.css` (line 1060)
- Kept the fix scoped to the toolbar, without changing runtime behavior or using `display: none` toggling

Tested locally, the fix works.
