### PR TITLE
feat: math-aware highlight for inline/block formulas

### DIFF
--- a/scripts/test-math-highlight.ts
+++ b/scripts/test-math-highlight.ts
@@ -1,0 +1,120 @@
+/**
+ * Run: npx tsx scripts/test-math-highlight.ts
+ */
+import assert from "assert";
+import {
+  findMathRanges,
+  expandOffsetsToFullMath,
+  cssColorToBboxColor,
+  applyBboxToMathInner,
+  applyBackgroundWithMath,
+  applyBackgroundToDocRange,
+  applyEqualsHighlightToDocRange,
+  stripMathBackgrounds,
+  stripOuterMathBackground,
+  toggleEqualsHighlightWithMath,
+  toggleEqualsHighlightInDocRange,
+  decideHighlightToggle,
+} from "../src/util/mathHighlight";
+
+{
+  const text = "故 $A^*$ 有 $\\frac{1}{2}$ 和 $$x=1$$ 结束";
+  const ranges = findMathRanges(text);
+  assert.strictEqual(ranges.length, 3);
+  assert.strictEqual(text.slice(ranges[0].start, ranges[0].end), "$A^*$");
+  assert.strictEqual(
+    text.slice(ranges[1].innerStart, ranges[1].innerEnd),
+    "\\frac{1}{2}"
+  );
+  assert.strictEqual(ranges[2].isBlock, true);
+}
+
+{
+  const doc = "前 $a+b$ 后";
+  const a = doc.indexOf("a");
+  const exp = expandOffsetsToFullMath(doc, a, a + 1);
+  assert.strictEqual(doc.slice(exp.from, exp.to), "$a+b$");
+}
+
+assert.strictEqual(cssColorToBboxColor("rgba(255, 248, 143)"), "#fff88f");
+assert.strictEqual(cssColorToBboxColor("#FFE066"), "#FFE066");
+
+{
+  const once = applyBboxToMathInner("x^2", "rgb(255, 248, 143)");
+  assert.strictEqual(once, "\\bbox[#fff88f]{x^2}");
+  const twice = applyBboxToMathInner(once, "#ff0000");
+  assert.strictEqual(twice, "\\bbox[#ff0000]{x^2}");
+}
+
+{
+  const input = "故 $A^*$ 有特征值 $\\frac{|A|}{\\lambda}$ 。";
+  const out = applyBackgroundWithMath(input, "rgb(255, 248, 143)");
+  assert.ok(
+    out.includes('<mark style="background:rgb(255, 248, 143)">故 </mark>')
+  );
+  assert.ok(out.includes("$\\bbox[#fff88f]{A^*}$"));
+  assert.ok(out.includes("$\\bbox[#fff88f]{\\frac{|A|}{\\lambda}}$"));
+  assert.ok(!out.match(/<mark[^>]*>\$/));
+}
+
+{
+  const highlighted = "故 $\\bbox[#fff88f]{A^*}$ 有";
+  assert.strictEqual(stripMathBackgrounds(highlighted), "故 $A^*$ 有");
+  assert.strictEqual(
+    stripOuterMathBackground("\\colorbox{yellow}{a+b}"),
+    "a+b"
+  );
+}
+
+// Behavior B: partial selection inside a formula only bboxes that slice
+{
+  const doc = "前 $\\lambda_1, \\lambda_2, \\dots$ 后";
+  const slice = "\\lambda_2";
+  const from = doc.indexOf(slice);
+  const to = from + slice.length;
+  const out = applyBackgroundToDocRange(doc, from, to, "#ffe066");
+  assert.strictEqual(out, "\\bbox[#ffe066]{\\lambda_2}");
+  // full formula must remain un-expanded
+  assert.ok(!out.includes("\\lambda_1"));
+  assert.ok(!out.includes("\\dots"));
+}
+
+{
+  const doc = "故 $\\lambda_1, \\lambda_2$ 结束";
+  const from = doc.indexOf("\\lambda_2");
+  const to = from + "\\lambda_2".length;
+  const out = applyEqualsHighlightToDocRange(doc, from, to);
+  assert.strictEqual(out, "\\bbox[#ffe066]{\\lambda_2}");
+}
+
+{
+  const input = "故 $A^*$ 有特征值";
+  const out = toggleEqualsHighlightWithMath(input);
+  assert.ok(out.includes("$\\bbox[#ffe066]{A^*}$"));
+  assert.ok(out.includes("=="));
+  for (const m of out.matchAll(/==([\s\S]*?)==/g)) {
+    assert.strictEqual(findMathRanges(m[1]).length, 0, `math inside ==: ${m[1]}`);
+  }
+
+  const broken = "==$\\lambda$ 是 $P^{-1}AP$ 的特征值==";
+  assert.strictEqual(decideHighlightToggle(broken), "repair");
+  const repaired = toggleEqualsHighlightWithMath(broken);
+  assert.ok(repaired.includes("\\bbox[#ffe066]{\\lambda}"));
+  assert.ok(repaired.includes("\\bbox[#ffe066]{P^{-1}AP}"));
+
+  const removed = toggleEqualsHighlightWithMath(repaired);
+  assert.ok(!removed.includes("\\bbox"));
+  assert.ok(!removed.includes("=="));
+}
+
+{
+  const doc = "前 $\\lambda_1, \\lambda_2$ 后";
+  const from = doc.indexOf("\\lambda_2");
+  const to = from + "\\lambda_2".length;
+  const on = toggleEqualsHighlightInDocRange(doc, from, to);
+  assert.strictEqual(on, "\\bbox[#ffe066]{\\lambda_2}");
+  const off = toggleEqualsHighlightInDocRange(on, 0, on.length);
+  assert.strictEqual(off, "\\lambda_2");
+}
+
+console.log("mathHighlight tests passed");

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -18,6 +18,10 @@ import {
   setBackgroundcolor,
   renumberSelection,
 } from "src/util/util";
+import {
+  toggleEqualsHighlightInDocRange,
+  DEFAULT_HIGHLIGHT_BBOX_COLOR,
+} from "src/util/mathHighlight";
 import { fullscreenMode, workplacefullscreenMode } from "src/util/fullscreen";
 import editingToolbarPlugin from "src/plugin/main";
 import { InsertCalloutModal } from "src/modals/insertCalloutModal";
@@ -1054,10 +1058,31 @@ export class CommandsManager {
       name: "Highlight",
       callback: () => {
         const editor = this.getActiveEditor();
-        editor &&
-          this.executeCommandWithoutBlur(editor, () =>
-            editor?.toggleMarkdownFormatting("highlight")
-          );
+        if (!editor) return;
+        this.executeCommandWithoutBlur(editor, () => {
+          const selectText = editor.getSelection();
+          if (!selectText || !selectText.trim()) {
+            editor.toggleMarkdownFormatting("highlight");
+            return;
+          }
+
+          try {
+            const fromOff = editor.posToOffset(editor.getCursor("from"));
+            const toOff = editor.posToOffset(editor.getCursor("to"));
+            // Behavior B: do not expand to full formula
+            const next = toggleEqualsHighlightInDocRange(
+              editor.getValue(),
+              fromOff,
+              toOff,
+              DEFAULT_HIGHLIGHT_BBOX_COLOR
+            );
+            if (next !== selectText) {
+              editor.replaceSelection(next);
+            }
+          } catch {
+            editor.toggleMarkdownFormatting("highlight");
+          }
+        });
       },
       icon: "highlight-glyph",
     });

--- a/src/modals/editingToolbarModal.ts
+++ b/src/modals/editingToolbarModal.ts
@@ -12,6 +12,7 @@ import { ViewUtils } from 'src/util/viewUtils';
 import { setBottomValue, setHorizontalValue } from "src/util/statusBarConstants";
 import { Editor } from "obsidian";
 import { setFontcolor, setBackgroundcolor } from "src/util/util";
+import { stripMathBackgrounds } from "src/util/mathHighlight";
 import { AI_TOOLBAR_COMMAND_ID } from "src/ai/toolbarCommand";
 import { AI_TOOLBOX_ACTIONS } from "src/ai/toolboxActions";
 import { DEFAULT_REWRITE_ACTIONS, type RewriteInstruction } from "src/ai/types";
@@ -719,6 +720,9 @@ export function setFormateraser(plugin: editingToolbarPlugin, editor: Editor) {
   selectText = selectText.replace(/\*\*\*([^\*]+)\*\*\*/g, "$1");
   selectText = selectText.replace(/\*\*?([^\*]+)\*\*?/g, "$1");
   selectText = selectText.replace(/~~([^~]+)~~/g, "$1");
+
+  // Strip MathJax \bbox / \colorbox inside formulas (and bare bbox fragments)
+  selectText = stripMathBackgrounds(selectText);
 
   // selectText = selectText.replace(/(\r*\n)+/mg, "\r\n");
   editor.replaceSelection(selectText);

--- a/src/util/mathHighlight.ts
+++ b/src/util/mathHighlight.ts
@@ -1,0 +1,440 @@
+/**
+ * Math-aware highlight helpers for Editing Toolbar.
+ * Applies MathJax \bbox to formula content without changing text color.
+ *
+ * Partial selection (behavior B): only the selected LaTeX slice gets \bbox;
+ * selection is NOT expanded to the full $...$ / $$...$$ span.
+ */
+
+export interface MathRange {
+  start: number;
+  end: number;
+  innerStart: number;
+  innerEnd: number;
+  isBlock: boolean;
+}
+
+type SegKind = "text" | "math-inner" | "delim";
+
+interface Seg {
+  start: number;
+  end: number;
+  kind: SegKind;
+}
+
+/** Find inline $...$ and block $$...$$ ranges (skips escaped \$). */
+export function findMathRanges(text: string): MathRange[] {
+  const ranges: MathRange[] = [];
+  let i = 0;
+  while (i < text.length) {
+    if (text[i] === "\\" && i + 1 < text.length) {
+      i += 2;
+      continue;
+    }
+    if (text.startsWith("$$", i)) {
+      const end = text.indexOf("$$", i + 2);
+      if (end === -1) break;
+      ranges.push({
+        start: i,
+        end: end + 2,
+        innerStart: i + 2,
+        innerEnd: end,
+        isBlock: true,
+      });
+      i = end + 2;
+      continue;
+    }
+    if (text[i] === "$") {
+      let j = i + 1;
+      while (j < text.length) {
+        if (text[j] === "\\" && j + 1 < text.length) {
+          j += 2;
+          continue;
+        }
+        if (text[j] === "$") break;
+        j++;
+      }
+      if (j >= text.length) break;
+      ranges.push({
+        start: i,
+        end: j + 1,
+        innerStart: i + 1,
+        innerEnd: j,
+        isBlock: false,
+      });
+      i = j + 1;
+      continue;
+    }
+    i++;
+  }
+  return ranges;
+}
+
+/**
+ * Expand [from, to) to full math spans (legacy behavior A).
+ * Kept for callers that opt in; default highlight paths do NOT use this.
+ */
+export function expandOffsetsToFullMath(
+  doc: string,
+  from: number,
+  to: number
+): { from: number; to: number } {
+  let newFrom = from;
+  let newTo = to;
+  for (const r of findMathRanges(doc)) {
+    if (r.start < to && r.end > from) {
+      newFrom = Math.min(newFrom, r.start);
+      newTo = Math.max(newTo, r.end);
+    }
+  }
+  return { from: newFrom, to: newTo };
+}
+
+/** Convert CSS colors with commas (rgba) to #rrggbb for \bbox optional args. */
+export function cssColorToBboxColor(color: string): string {
+  const rgba = color.match(
+    /rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)(?:\s*,\s*[\d.]+)?\s*\)/i
+  );
+  if (rgba) {
+    const hex = (n: string) =>
+      Math.max(0, Math.min(255, Number(n)))
+        .toString(16)
+        .padStart(2, "0");
+    return `#${hex(rgba[1])}${hex(rgba[2])}${hex(rgba[3])}`;
+  }
+  return color.trim();
+}
+
+function findMatchingBrace(text: string, openIdx: number): number {
+  if (text[openIdx] !== "{") return -1;
+  let depth = 0;
+  for (let i = openIdx; i < text.length; i++) {
+    if (text[i] === "\\" && i + 1 < text.length) {
+      i++;
+      continue;
+    }
+    if (text[i] === "{") depth++;
+    else if (text[i] === "}") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/** Strip a single outer \bbox[...]{...} or \colorbox{...}{...} if it wraps the whole string. */
+export function stripOuterMathBackground(inner: string): string {
+  const s = inner.trim();
+  if (s.startsWith("\\bbox")) {
+    let i = "\\bbox".length;
+    while (i < s.length && /\s/.test(s[i])) i++;
+    if (s[i] === "[") {
+      const close = s.indexOf("]", i);
+      if (close === -1) return inner;
+      i = close + 1;
+      while (i < s.length && /\s/.test(s[i])) i++;
+    }
+    if (s[i] !== "{") return inner;
+    const end = findMatchingBrace(s, i);
+    if (end === -1) return inner;
+    if (s.slice(end + 1).trim() !== "") return inner;
+    return s.slice(i + 1, end);
+  }
+  if (s.startsWith("\\colorbox")) {
+    let i = "\\colorbox".length;
+    while (i < s.length && /\s/.test(s[i])) i++;
+    if (s[i] !== "{") return inner;
+    const colorEnd = findMatchingBrace(s, i);
+    if (colorEnd === -1) return inner;
+    i = colorEnd + 1;
+    while (i < s.length && /\s/.test(s[i])) i++;
+    if (s[i] !== "{") return inner;
+    const end = findMatchingBrace(s, i);
+    if (end === -1) return inner;
+    if (s.slice(end + 1).trim() !== "") return inner;
+    return s.slice(i + 1, end);
+  }
+  return inner;
+}
+
+export function applyBboxToMathInner(inner: string, color: string): string {
+  const body = stripOuterMathBackground(inner);
+  const bboxColor = cssColorToBboxColor(color);
+  return `\\bbox[${bboxColor}]{${body}}`;
+}
+
+/** Apply existing <mark> background wrap to non-math text. */
+export function applyMarkBackground(text: string, color: string): string {
+  if (!text) return text;
+  const bgColorRegex =
+    /<mark\s+style=["']?background:(?:#[0-9a-fA-F]{3,6}|rgba?\([^)]+\))["']?>([\s\S]*?)<\/mark>/g;
+  const hasColorTag = bgColorRegex.test(text);
+  bgColorRegex.lastIndex = 0;
+
+  const escapedColor = color.replace(/([()[{*+.$^\\|?])/g, "\\$1");
+  const cleanColorRegex = new RegExp(
+    `^<mark\\s+style=["']?background:${escapedColor}["']?>([\\s\\S]+)<\\/mark>$`
+  );
+  if (cleanColorRegex.test(text.trim())) {
+    return text;
+  }
+
+  if (hasColorTag) {
+    return text.replace(
+      /(background:)(?:#[0-9a-fA-F]{3,6}|rgba?\([^)]+\))/gi,
+      `$1${color}`
+    );
+  }
+  return text
+    .split("\n")
+    .map((line) =>
+      line.trim() ? `<mark style="background:${color}">${line}</mark>` : line
+    )
+    .join("\n");
+}
+
+/** Build text / math-inner / delimiter segments inside [from, to). */
+export function buildMathAwareSegments(
+  doc: string,
+  from: number,
+  to: number
+): Seg[] {
+  if (from >= to) return [];
+  const ranges = findMathRanges(doc);
+  const cuts = new Set<number>([from, to]);
+  for (const r of ranges) {
+    if (r.end <= from || r.start >= to) continue;
+    cuts.add(Math.max(r.start, from));
+    cuts.add(Math.min(r.innerStart, to));
+    cuts.add(Math.max(r.innerStart, from));
+    cuts.add(Math.min(r.innerEnd, to));
+    cuts.add(Math.max(r.innerEnd, from));
+    cuts.add(Math.min(r.end, to));
+  }
+  const points = [...cuts]
+    .filter((p) => p >= from && p <= to)
+    .sort((a, b) => a - b);
+
+  const segs: Seg[] = [];
+  for (let i = 0; i < points.length - 1; i++) {
+    const a = points[i];
+    const b = points[i + 1];
+    if (a === b) continue;
+    const mid = (a + b) / 2;
+    let kind: SegKind = "text";
+    for (const r of ranges) {
+      if (mid >= r.innerStart && mid < r.innerEnd) {
+        kind = "math-inner";
+        break;
+      }
+      if (
+        (mid >= r.start && mid < r.innerStart) ||
+        (mid >= r.innerEnd && mid < r.end)
+      ) {
+        kind = "delim";
+        break;
+      }
+    }
+    segs.push({ start: a, end: b, kind });
+  }
+  return segs;
+}
+
+/**
+ * Transform a document range with behavior B (no expand-to-full-formula).
+ * Delimiters stay raw; math-inner slices get onMathInner; other text gets onText.
+ */
+export function transformDocRange(
+  doc: string,
+  from: number,
+  to: number,
+  onText: (slice: string) => string,
+  onMathInner: (slice: string) => string
+): string {
+  let result = "";
+  for (const seg of buildMathAwareSegments(doc, from, to)) {
+    const slice = doc.slice(seg.start, seg.end);
+    if (seg.kind === "delim") result += slice;
+    else if (seg.kind === "math-inner") result += onMathInner(slice);
+    else result += onText(slice);
+  }
+  return result;
+}
+
+export function applyBackgroundToDocRange(
+  doc: string,
+  from: number,
+  to: number,
+  color: string
+): string {
+  return transformDocRange(
+    doc,
+    from,
+    to,
+    (text) => applyMarkBackground(text, color),
+    (inner) => applyBboxToMathInner(inner, color)
+  );
+}
+
+/**
+ * Highlight selection string: non-math → <mark>; math spans → \bbox.
+ * Prefer applyBackgroundToDocRange when editor offsets are available (partial math).
+ */
+export function applyBackgroundWithMath(text: string, color: string): string {
+  return applyBackgroundToDocRange(text, 0, text.length, color);
+}
+
+/** Remove outer \bbox / \colorbox inside every math span. */
+export function stripMathBackgrounds(text: string): string {
+  const ranges = findMathRanges(text);
+  if (ranges.length === 0) {
+    return stripOuterMathBackground(text);
+  }
+
+  let result = "";
+  let last = 0;
+  for (const r of ranges) {
+    result += text.slice(last, r.start);
+    const open = text.slice(r.start, r.innerStart);
+    const inner = text.slice(r.innerStart, r.innerEnd);
+    const close = text.slice(r.innerEnd, r.end);
+    result += open + stripOuterMathBackground(inner) + close;
+    last = r.end;
+  }
+  result += text.slice(last);
+  return result;
+}
+
+/** Default color approximating Obsidian --text-highlight-bg (opaque for \\bbox). */
+export const DEFAULT_HIGHLIGHT_BBOX_COLOR = "#ffe066";
+
+function wrapEqualsSegments(text: string): string {
+  if (!text) return text;
+  if (/^==[\s\S]*==$/.test(text.trim()) && text.trim().startsWith("==")) {
+    return text;
+  }
+  return text
+    .split("\n")
+    .map((line) => {
+      if (!line) return line;
+      const trimmed = line.trim();
+      if (trimmed.startsWith("==") && trimmed.endsWith("==")) return line;
+      return `==${line}==`;
+    })
+    .join("\n");
+}
+
+function unwrapEquals(text: string): string {
+  return text.replace(/==([\s\S]*?)==/g, "$1");
+}
+
+function containsMath(text: string): boolean {
+  return findMathRanges(text).length > 0;
+}
+
+function containsMathBbox(text: string): boolean {
+  return /\\bbox\s*[\[{]/.test(text) || /\\colorbox\s*\{/.test(text);
+}
+
+export function applyEqualsHighlightToDocRange(
+  doc: string,
+  from: number,
+  to: number,
+  color: string = DEFAULT_HIGHLIGHT_BBOX_COLOR
+): string {
+  return transformDocRange(
+    doc,
+    from,
+    to,
+    (text) => wrapEqualsSegments(text),
+    (inner) => applyBboxToMathInner(inner, color)
+  );
+}
+
+/**
+ * Markdown ==highlight== with math: text → ==...==, formulas → \\bbox.
+ */
+export function applyEqualsHighlightWithMath(
+  text: string,
+  color: string = DEFAULT_HIGHLIGHT_BBOX_COLOR
+): string {
+  return applyEqualsHighlightToDocRange(text, 0, text.length, color);
+}
+
+export function stripEqualsHighlightWithMath(text: string): string {
+  return stripMathBackgrounds(unwrapEquals(text));
+}
+
+export type HighlightToggleMode = "apply" | "remove" | "repair";
+
+/**
+ * Decide highlight toggle behavior for a selection.
+ * - repair: ==...$math$...== without bbox → rewrite to math-aware form
+ * - remove: already math-aware or plain == → strip
+ * - apply: add highlight
+ */
+export function decideHighlightToggle(text: string): HighlightToggleMode {
+  const trimmed = text.trim();
+  const hasEquals = /==[\s\S]*?==/.test(text);
+  const hasMath = containsMath(unwrapEquals(text));
+  const hasBbox = containsMathBbox(text);
+
+  if (hasEquals && hasMath && !hasBbox) {
+    return "repair";
+  }
+  if (
+    hasBbox ||
+    (hasEquals && trimmed.startsWith("==") && trimmed.endsWith("=="))
+  ) {
+    return "remove";
+  }
+  return "apply";
+}
+
+export function toggleEqualsHighlightWithMath(
+  text: string,
+  color: string = DEFAULT_HIGHLIGHT_BBOX_COLOR
+): string {
+  const mode = decideHighlightToggle(text);
+  if (mode === "repair") {
+    return applyEqualsHighlightWithMath(unwrapEquals(text), color);
+  }
+  if (mode === "remove") {
+    return stripEqualsHighlightWithMath(text);
+  }
+  return applyEqualsHighlightWithMath(text, color);
+}
+
+/**
+ * Toggle highlight using document offsets (supports partial math, behavior B).
+ */
+export function toggleEqualsHighlightInDocRange(
+  doc: string,
+  from: number,
+  to: number,
+  color: string = DEFAULT_HIGHLIGHT_BBOX_COLOR
+): string {
+  const selected = doc.slice(from, to);
+  const mode = decideHighlightToggle(selected);
+
+  if (mode === "remove") {
+    return transformDocRange(
+      doc,
+      from,
+      to,
+      (text) => stripOuterMathBackground(unwrapEquals(text)),
+      (inner) => stripOuterMathBackground(inner)
+    );
+  }
+
+  if (mode === "repair") {
+    return applyEqualsHighlightToDocRange(
+      unwrapEquals(selected),
+      0,
+      unwrapEquals(selected).length,
+      color
+    );
+  }
+
+  return applyEqualsHighlightToDocRange(doc, from, to, color);
+}

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,5 +1,6 @@
 import { Editor,Command,MarkdownView } from "obsidian";
 import { syntaxTree } from '@codemirror/language';
+import { applyBackgroundToDocRange } from "src/util/mathHighlight";
 export async function wait(delay: number) {
   return new Promise((resolve) => setTimeout(resolve, delay));
 }
@@ -328,73 +329,45 @@ export function setBackgroundcolor(color: string, editor?: Editor) {
     return;
   }
 
-  // Regex to match background color tags, with multiline support
-  const bgColorRegex = /<mark\s+style=["']?background:(?:#[0-9a-fA-F]{3,6}|rgba?\([^)]+\))["']?>([\s\S]*?)<\/mark>/g;
-  const hasColorTag = bgColorRegex.test(selectText);
+  let finalText = selectText;
+  try {
+    const fromOff = editor.posToOffset(editor.getCursor("from"));
+    const toOff = editor.posToOffset(editor.getCursor("to"));
+    // Behavior B: do not expand to full $...$; only selected LaTeX slices get \bbox
+    finalText = applyBackgroundToDocRange(
+      editor.getValue(),
+      fromOff,
+      toOff,
+      color
+    );
+  } catch {
+    finalText = applyBackgroundToDocRange(selectText, 0, selectText.length, color);
+  }
 
-  // Function to check if the text is already wrapped in the same background color
-  const isAlreadyInSameColor = (text: string, targetColor: string): boolean => {
-    // 转义正则表达式中的特殊字符，特别是对于rgba格式
-    const escapedColor = targetColor.replace(/([()[{*+.$^\\|?])/g, '\\$1');
-    const cleanColorRegex = new RegExp(`^<mark\\s+style=["']?background:${escapedColor}["']?>([\s\S]+)<\\/mark>$`);
-    return cleanColorRegex.test(text.trim());
-  };
-
-  // If the text is already in the same color, do nothing
-  if (isAlreadyInSameColor(selectText, color)) {
+  if (finalText === selectText) {
     return;
   }
 
-  let finalText;
-  
-  if (hasColorTag) {
-    // 如果已经有背景色标签，只替换颜色值
-    finalText = selectText.replace(/(background:)(?:#[0-9a-fA-F]{3,6}|rgba?\([^)]+\))/gi, `$1${color}`);
-  } else {
-    // 如果没有背景色标签，为每行添加背景色
-    finalText = selectText.split('\n').map(line => 
-      line.trim() ? `<mark style="background:${color}">${line}</mark>` : line
-    ).join('\n');
-  }
-
-  // Store the current selection
+  const lengthDelta = finalText.length - selectText.length;
   const currentSelection = editor.listSelections();
-  const adjustedSelections = currentSelection.map(sel => {
-    const tagLength = hasColorTag ? 0 : `<mark style="background:${color}"></mark>`.length;
-    const isForward = sel.anchor.line < sel.head.line || 
-                      (sel.anchor.line === sel.head.line && sel.anchor.ch < sel.head.ch);
+  const adjustedSelections = currentSelection.map((sel) => {
+    const isForward =
+      sel.anchor.line < sel.head.line ||
+      (sel.anchor.line === sel.head.line && sel.anchor.ch < sel.head.ch);
 
     if (isForward) {
-      // 从前到后选择
       return {
-        anchor: {
-          line: sel.anchor.line,
-          ch: sel.anchor.ch
-        },
-        head: {
-          line: sel.head.line,
-          ch: sel.head.ch + tagLength
-        }
-      };
-    } else {
-      // 从后到前选择
-      return {
-        anchor: {
-          line: sel.anchor.line,
-          ch: sel.anchor.ch + tagLength
-        },
-        head: {
-          line: sel.head.line,
-          ch: sel.head.ch
-        }
+        anchor: { line: sel.anchor.line, ch: sel.anchor.ch },
+        head: { line: sel.head.line, ch: sel.head.ch + lengthDelta },
       };
     }
+    return {
+      anchor: { line: sel.anchor.line, ch: sel.anchor.ch + lengthDelta },
+      head: { line: sel.head.line, ch: sel.head.ch },
+    };
   });
 
-  // Replace the selection
   editor.replaceSelection(finalText);
-
-  // Restore the original selection
   editor.setSelections(adjustedSelections);
 }
 // 重编号选中的行

--- a/styles.css
+++ b/styles.css
@@ -2734,3 +2734,18 @@ body.auto-hide-header .workspace-tab-header-container + .workspace-tab-container
 .editing-toolbar-ai-inline-body .setting-item {
   border-top: 1px solid var(--background-modifier-border-hover);
 }
+
+/* ---- Math-aware highlight (Editing Toolbar) ---- */
+.markdown-rendered mark mjx-container,
+.markdown-preview-view mark mjx-container,
+.markdown-reading-view mark mjx-container {
+  background-color: var(--text-highlight-bg) !important;
+  padding: 0.05em 0.12em;
+  border-radius: 2px;
+}
+
+.markdown-source-view.mod-cm6 .cm-highlight + .cm-widgetBuffer + span.math,
+.markdown-source-view.mod-cm6 .cm-highlight + .cm-widgetBuffer + .math {
+  background-color: var(--text-highlight-bg) !important;
+  border-radius: 2px;
+}


### PR DESCRIPTION
## Summary
- Highlight (`==...==`) and background-color (`<mark>`) now apply MathJax `\bbox` to selected formula content, so MathJax no longer stays unhighlighted while surrounding text is highlighted.
- **Partial selection** only colors the selected LaTeX slice (does not expand to the full `$...$` / `$$...$$`).
- Format eraser also strips `\bbox` / `\colorbox` from formulas (and bare bbox fragments).
- Adds a small CSS assist for math inside `<mark>` / adjacent to `.cm-highlight` in Live Preview / reading view.
- Includes unit tests in `scripts/test-math-highlight.ts` (`npx tsx scripts/test-math-highlight.ts`).

## Motivation
Obsidian MathJax widgets do not inherit Markdown `==highlight==` or HTML `<mark>` backgrounds. This is a long-standing pain point for math-heavy notes (see also related discussions around highlighting inline math).

## Test plan
- [ ] Select text that includes `$...$` / `$$...$$`, click Highlight → surrounding text uses `==`, formulas gain `\bbox[#ffe066]{...}`
- [ ] Select only `\lambda_2` inside `$\lambda_1, \lambda_2, \dots$`, click Highlight → only `\lambda_2` wrapped with `\bbox`, rest of formula unchanged
- [ ] Background-color picker on mixed text+math → text gets `<mark>`, selected math slices get `\bbox`
- [ ] Click Highlight again on a math-aware selection → formatting removed (including `\bbox`)
- [ ] Format eraser on selection with formula `\bbox` → bbox removed
- [ ] Re-click Highlight on legacy `==...$math$...==` → repairs into math-aware form
- [ ] `npx tsx scripts/test-math-highlight.ts` passes
