### PR TITLE
Add thinking mode control for OpenAI-compatible custom models

### DIFF
--- a/src/ai/AIService.ts
+++ b/src/ai/AIService.ts
@@ -4,7 +4,7 @@ import { t } from "src/translations/helper";
 import { AIUserNoticeError, getAIErrorMessage, getRequestErrorStatus } from "./errorHandling";
 import { resolvePKMerModelForScene } from "./types";
 import type { CompletionParams, IAIService, PKMerModelScene, RewriteArtifactKind, RewriteInstruction, RewriteParams } from "./types";
-import type { CustomModelApiFormat } from "./types";
+import type { CustomModelApiFormat, CustomModelThinkingMode } from "./types";
 import { PKMerAuthService } from "./PKMerAuthService";
 import { AIUrlHelper } from "./urlValidation";
 
@@ -15,6 +15,7 @@ interface ResolvedProvider {
   apiKey: string;
   model: string;
   temperature: number;
+  thinkingMode: CustomModelThinkingMode;
 }
 
 interface CustomProviderValidationResult {
@@ -327,13 +328,23 @@ export class ToolbarAIService implements IAIService {
       return this.buildGeminiRequestBody(provider, messages, options);
     }
 
-    return {
+    const body: Record<string, unknown> = {
       model: provider.model,
       temperature: provider.temperature,
       max_tokens: options.maxTokens,
       stream: false,
       messages,
     };
+
+    if (
+      provider.kind === "custom"
+      && provider.apiFormat === "openai-compatible"
+      && provider.thinkingMode !== "auto"
+    ) {
+      body.thinking = { type: provider.thinkingMode };
+    }
+
+    return body;
   }
 
   private buildOllamaRequestBody(
@@ -433,6 +444,7 @@ export class ToolbarAIService implements IAIService {
       apiKey: this.authService.aiToken,
       model: resolvePKMerModelForScene(settings, scene),
       temperature: settings.customModel.temperature,
+      thinkingMode: "auto",
     };
   }
 
@@ -468,6 +480,7 @@ export class ToolbarAIService implements IAIService {
         apiKey: customApiKey,
         model: custom.model.trim(),
         temperature: custom.temperature,
+        thinkingMode: custom.thinkingMode ?? "auto",
       },
       missing: [],
     };
@@ -490,6 +503,7 @@ export class ToolbarAIService implements IAIService {
       apiKey,
       model: custom.model.trim(),
       temperature: custom.temperature,
+      thinkingMode: custom.thinkingMode ?? "auto",
     };
   }
 

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -87,12 +87,15 @@ export interface PKMerAuthSettings {
   userInfo: PKMerUserInfo | null;
 }
 
+export type CustomModelThinkingMode = "auto" | "disabled" | "enabled";
+
 export interface CustomModelSettings {
   apiFormat: CustomModelApiFormat;
   baseUrl: string;
   apiKey: string;
   model: string;
   temperature: number;
+  thinkingMode: CustomModelThinkingMode;
 }
 
 export type CustomModelApiFormat = "openai-compatible" | "ollama" | "gemini";
@@ -426,6 +429,7 @@ export const DEFAULT_AI_SETTINGS: AIPluginSettings = {
     apiKey: "",
     model: "",
     temperature: 0.2,
+    thinkingMode: "auto",
   },
   frontmatterPrompt: createDefaultFrontmatterPromptSettings(),
   customPromptHistory: [],

--- a/src/settings/settingsTab.ts
+++ b/src/settings/settingsTab.ts
@@ -20,7 +20,7 @@ import { RegexCommandModal } from "src/modals/RegexCommandModal";
 import { ButtonComponent } from "obsidian";
 import { ConfirmModal } from "src/modals/ConfirmModal";
 import { createDefaultFrontmatterPromptSettings, getDefaultCustomPromptTemplates, PKMER_MODEL_OPTIONS, resolvePKMerModelForScene } from "src/ai/types";
-import type { CustomModelApiFormat } from "src/ai/types";
+import type { CustomModelApiFormat, CustomModelThinkingMode } from "src/ai/types";
 import { AIUrlHelper } from "src/ai/urlValidation";
 import { getAIErrorMessage } from "src/ai/errorHandling";
 import { getPKMerAIEntryUrl, getPKMerAIQuotaUrl } from "src/ai/pkmerWeb";
@@ -3569,6 +3569,23 @@ export class editingToolbarSettingTab extends PluginSettingTab {
         const moreOptions = customBody.createEl('details', { cls: 'editing-toolbar-ai-inline-disclosure' });
         moreOptions.createEl('summary', { cls: 'editing-toolbar-ai-inline-summary', text: t('More Options') });
         const moreOptionsBody = moreOptions.createDiv('editing-toolbar-ai-inline-body');
+
+        if (customApiFormat === 'openai-compatible') {
+          new Setting(moreOptionsBody)
+            .setName(t('Thinking Mode'))
+            .setDesc(t('Auto leaves provider behavior unchanged. Explicit modes are intended for compatible providers such as DeepSeek.'))
+            .addDropdown((dropdown) => {
+              dropdown
+                .addOption('auto', t('Auto'))
+                .addOption('disabled', t('Disabled'))
+                .addOption('enabled', t('Enabled'))
+                .setValue(this.plugin.settings.ai.customModel.thinkingMode ?? 'auto')
+                .onChange(async (value) => {
+                  this.plugin.settings.ai.customModel.thinkingMode = value as CustomModelThinkingMode;
+                  await this.plugin.saveSettings();
+                });
+            });
+        }
 
         new Setting(moreOptionsBody)
           .setName(t('Temperature'))

--- a/src/translations/locale/en.ts
+++ b/src/translations/locale/en.ts
@@ -728,6 +728,8 @@ export default {
   'Current Obsidian version does not support secure secret storage.': 'Current Obsidian version does not support secure secret storage.',
   'Stored securely': 'Stored securely',
   'Enter API key': 'Enter API key',
+  'Thinking Mode': 'Thinking Mode',
+  'Auto leaves provider behavior unchanged. Explicit modes are intended for compatible providers such as DeepSeek.': 'Auto leaves provider behavior unchanged. Explicit modes are intended for compatible providers such as DeepSeek.',
   'Temperature': 'Temperature',
   'Lower values are more stable; higher values are more creative.': 'Lower values are more stable; higher values are more creative.',
   'Test Connection': 'Test Connection',

--- a/src/translations/locale/zh-cn.ts
+++ b/src/translations/locale/zh-cn.ts
@@ -747,6 +747,8 @@ export default {
   'Current Obsidian version does not support secure secret storage.': '当前 Obsidian 版本不支持安全秘密存储。',
   'Stored securely': '已安全存储',
   'Enter API key': '输入 API Key',
+  'Thinking Mode': '推理模式',
+  'Auto leaves provider behavior unchanged. Explicit modes are intended for compatible providers such as DeepSeek.': '自动模式保持服务方的默认行为；显式模式适用于 DeepSeek 等兼容服务。',
   'Temperature': '温度',
   'Lower values are more stable; higher values are more creative.': '更低的值更稳定，更高的值更具创造性。',
   'Test Connection': '测试连接',


### PR DESCRIPTION
## Summary

- add an `auto` / `disabled` / `enabled` thinking-mode setting for custom models
- expose the setting only for OpenAI-compatible custom providers
- send `thinking: { type: ... }` only when the user explicitly selects `disabled` or `enabled`
- add English and Simplified Chinese labels and guidance

## Why

DeepSeek V4 models use thinking mode by default and count reasoning tokens in `max_tokens`. Editing Toolbar's intentionally small inline-completion budgets can therefore be consumed before a final `message.content` is produced. Users who want fast inline completion need a way to request non-thinking mode.

The default is `auto`, which omits the provider-specific field and preserves existing behavior. PKMer, Ollama, and Gemini request bodies are unchanged.

## Validation

- `npm run build` ✅
- `git diff --check` ✅
- `npx tsc --noEmit` currently reports pre-existing conflicts between the bundled Obsidian declarations and `src/types/obsidian.d.ts`; none of the reported files are changed by this PR

Closes #354
